### PR TITLE
proposed change to remove requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-boto3==1.7.2
-dockerflow==2018.4.0
-requests==2.19.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,0 @@
-moto==1.3.5
-pytest==3.7.4
-pytest-cov==2.5.1
-pytest-flake8==1.0.2
-requests-mock==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 from setuptools import find_packages, setup
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-with open('requirements_test.txt') as f:
-    test_requirements = f.read().splitlines()
-
 setup(
     # Meta
     author='Mozilla Foundation',
@@ -26,11 +21,18 @@ setup(
     """,
     name='mozilla-srgutil',
     url='https://github.com/mozilla/srgutil',
-    version='0.1.9',
+    version='0.1.10',
 
     # Dependencies
-    install_requires=requirements,
-    tests_require=test_requirements,
+
+    # Note that we only care about unversioned requirements in
+    # setup.py.  We pin those versions with requirements.txt
+    install_requires=['boto3==1.7.2',  # 1.7.2 won't break with moto >=1.3.5.
+                                       # More recent versions of boto3
+                                       # will die under test
+                      'dockerflow>=2018.4.0',
+                      'requests>=2.19.1'],
+    tests_require=['moto>=1.3.5', 'pytest>=3.7.4', 'pytest-cov>=2.5.1', 'pytest-flake8>=1.0.2', 'requests-mock>=1.5.2'],
     setup_requires=['pytest-runner', 'dockerflow'],
 
     # Packaging


### PR DESCRIPTION
This is an attempt to simplify package upgrades across library and application layers of
TAAR(lite) by dropping the requirements file and only specifying minimal version requirements in setup.py.

I think we should be reserving requirements.txt strictly for deployment purposes.