### PR TITLE
Proposed change to remove requirements files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ before_install:
 install:
 - sudo apt-get update
 - pip install .
-- pip install -r requirements.txt
-- pip install -r requirements_test.txt
 
 script:
 - py.test --cov srgutil tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
 - pip install .
 
 script:
-- py.test --cov srgutil tests
+- python setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-boto3==1.7.2
-dockerflow==2018.4.0
-requests==2.19.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,0 @@
-moto==1.3.5
-pytest==3.7.4
-pytest-cov==2.5.1
-pytest-flake8==1.0.2
-requests-mock==1.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ test=pytest
 max-line-length = 120
 
 [tool:pytest]
-addopts = --flake8 -rws
+addopts = --flake8 -rws --cov srgutil tests

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import find_packages, setup
 
 setup(
     # Meta
-    author='Mozilla Foundation',
-    author_email='fx-data-dev@mozilla.org',
-    description='SRG utilities',
-    license='MPL 2.0',
+    author="Mozilla Foundation",
+    author_email="fx-data-dev@mozilla.org",
+    description="SRG utilities",
+    license="MPL 2.0",
     long_description="""srgutil provides set of common tools required
     for use with TAAR and other SRG applications.
 
@@ -19,40 +19,44 @@ setup(
     * S3 APIs to write date stamped files into S3 in a consistent
       manner.
     """,
-    name='mozilla-srgutil',
-    url='https://github.com/mozilla/srgutil',
-    version='0.1.10',
-
+    name="mozilla-srgutil",
+    url="https://github.com/mozilla/srgutil",
+    version="0.1.10",
     # Dependencies
-
     # Note that we only care about unversioned requirements in
     # setup.py.  We pin those versions with requirements.txt
-    install_requires=['boto3==1.7.2',  # 1.7.2 won't break with moto >=1.3.5.
-                                       # More recent versions of boto3
-                                       # will die under test
-                      'dockerflow>=2018.4.0',
-                      'requests>=2.19.1'],
-    tests_require=['moto>=1.3.5', 'pytest>=3.7.4', 'pytest-cov>=2.5.1', 'pytest-flake8>=1.0.2', 'requests-mock>=1.5.2'],
-    setup_requires=['pytest-runner', 'dockerflow'],
-
+    install_requires=[
+        "boto3==1.7.2",  # 1.7.2 won't break with moto >=1.3.5.
+        # More recent versions of boto3
+        # will die under test
+        "dockerflow>=2018.4.0",
+        "requests>=2.19.1",
+    ],
+    tests_require=[
+        "moto>=1.3.5",
+        "pytest>=3.7.4",
+        "pytest-cov>=2.5.1",
+        "pytest-flake8>=1.0.2",
+        "requests-mock>=1.5.2",
+    ],
+    setup_requires=["pytest-runner", "dockerflow"],
     # Packaging
     include_package_data=True,
-    packages=find_packages(exclude=['tests', 'tests/*']),
+    packages=find_packages(exclude=["tests", "tests/*"]),
     zip_safe=False,
-
     # Classifiers
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Environment :: Web Environment :: Mozilla',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Internet :: WWW/HTTP',
-        'Topic :: Scientific/Engineering :: Information Analysis'
+        "Development Status :: 3 - Alpha",
+        "Environment :: Web Environment :: Mozilla",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Scientific/Engineering :: Information Analysis",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 from setuptools import find_packages, setup
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-with open('requirements_test.txt') as f:
-    test_requirements = f.read().splitlines()
-
 setup(
     # Meta
     author='Mozilla Foundation',
@@ -26,11 +21,18 @@ setup(
     """,
     name='mozilla-srgutil',
     url='https://github.com/mozilla/srgutil',
-    version='0.1.9',
+    version='0.1.10',
 
     # Dependencies
-    install_requires=requirements,
-    tests_require=test_requirements,
+
+    # Note that we only care about unversioned requirements in
+    # setup.py.  We pin those versions with requirements.txt
+    install_requires=['boto3==1.7.2',  # 1.7.2 won't break with moto >=1.3.5.
+                                       # More recent versions of boto3
+                                       # will die under test
+                      'dockerflow>=2018.4.0',
+                      'requests>=2.19.1'],
+    tests_require=['moto>=1.3.5', 'pytest>=3.7.4', 'pytest-cov>=2.5.1', 'pytest-flake8>=1.0.2', 'requests-mock>=1.5.2'],
     setup_requires=['pytest-runner', 'dockerflow'],
 
     # Packaging


### PR DESCRIPTION
This removes the requirements files and instead expresses dependencies directly in setup.py

This is an attempt to simplify the package upgrade problem when a library dependency requires a mandatory upgrade.

I'd like to have requirements.txt files only specified in deployment scenarios so that we know what is going out to production in case we need to reproduce a test environment.